### PR TITLE
Fix native FFI output-buffer overflow on large range-proof widths

### DIFF
--- a/c/include/wabisabi_ffi.h
+++ b/c/include/wabisabi_ffi.h
@@ -72,6 +72,15 @@ _Static_assert(WABISABI_IPARAMS_SIZE == 66, "iparams size mismatch");
 #define WABISABI_ISSUER_MSTATE_MAX_SIZE \
     (8 + 4 + WABISABI_MAX_SERIAL_NUMBERS * WABISABI_GE_SIZE)
 
+/* Upper bound on a serialized request/response for any range-proof width up to
+ * WABISABI_MAX_RANGE_WIDTH. A real request grows with the range-proof width
+ * (range proofs scale ~linearly with the number of bits); at the maximum width
+ * it is ~21 KiB. 64 KiB is always sufficient and is the recommended size for
+ * the req_out / resp_out buffers. NOTE: a fixed 16 KiB buffer is NOT enough —
+ * a real request for a large max_amount (e.g. 43,000 BTC -> width 42 -> ~17.6
+ * KiB) overruns it. Always pass the true buffer capacity (see *_cap params). */
+#define WABISABI_MAX_REQUEST_SIZE (64 * 1024)
+
 /* ---- Error codes ---- */
 typedef enum {
     WABISABI_OK = 0,
@@ -85,6 +94,7 @@ typedef enum {
     WABISABI_ERR_SERIAL_REUSED = 8,
     WABISABI_ERR_NEGATIVE_BALANCE = 9,
     WABISABI_ERR_SERIAL_SET_FULL = 10, /* serial number set at capacity */
+    WABISABI_ERR_BUFFER_TOO_SMALL = 11, /* an output buffer capacity is too small for the result */
 } wabisabi_error_t;
 
 #ifdef __cplusplus
@@ -116,9 +126,11 @@ wabisabi_error_t wabisabi_iparams_from_sk(const uint8_t* sk_bytes, uint8_t* out_
  * req_bytes     : wire-encoded ZeroRequest.
  * req_len       : byte length of req_bytes.
  * rand_bytes    : WABISABI_RAND_SIZE bytes of fresh randomness for MAC issuance.
- * resp_out      : output buffer; 16 KiB is always sufficient.
+ * resp_out      : output buffer for the response (use WABISABI_MAX_REQUEST_SIZE bytes).
+ * resp_out_cap  : capacity of resp_out in bytes; returns WABISABI_ERR_BUFFER_TOO_SMALL if too small.
  * resp_len_out  : set to actual response length on success.
  * mstate_out    : output buffer for updated mutable state (WABISABI_ISSUER_MSTATE_MAX_SIZE bytes).
+ * mstate_out_cap: capacity of mstate_out in bytes; returns WABISABI_ERR_BUFFER_TOO_SMALL if too small.
  * mstate_out_len: set to actual mutable state length on success.
  */
 wabisabi_error_t wabisabi_issuer_handle_zero(
@@ -127,8 +139,8 @@ wabisabi_error_t wabisabi_issuer_handle_zero(
     const uint8_t* mstate_in, int mstate_in_len,
     const uint8_t* req_bytes, int req_len,
     const uint8_t* rand_bytes,
-    uint8_t* resp_out, int* resp_len_out,
-    uint8_t* mstate_out, int* mstate_out_len);
+    uint8_t* resp_out, int resp_out_cap, int* resp_len_out,
+    uint8_t* mstate_out, int mstate_out_cap, int* mstate_out_len);
 
 /**
  * Handle a real credential request. Same parameters as wabisabi_issuer_handle_zero.
@@ -139,8 +151,8 @@ wabisabi_error_t wabisabi_issuer_handle_real(
     const uint8_t* mstate_in, int mstate_in_len,
     const uint8_t* req_bytes, int req_len,
     const uint8_t* rand_bytes,
-    uint8_t* resp_out, int* resp_len_out,
-    uint8_t* mstate_out, int* mstate_out_len);
+    uint8_t* resp_out, int resp_out_cap, int* resp_len_out,
+    uint8_t* mstate_out, int mstate_out_cap, int* mstate_out_len);
 
 /* ---- Client (stateless) ---- */
 
@@ -148,14 +160,15 @@ wabisabi_error_t wabisabi_issuer_handle_real(
  * Create a zero (bootstrap) credential request.
  *
  * rand_bytes   : WABISABI_RAND_SIZE bytes of randomness.
- * req_out      : output buffer; 16 KiB is always sufficient.
+ * req_out      : output buffer for the request (use WABISABI_MAX_REQUEST_SIZE bytes).
+ * req_out_cap  : capacity of req_out in bytes; returns WABISABI_ERR_BUFFER_TOO_SMALL if too small.
  * req_len_out  : set to actual request length on success.
  * val_out      : output buffer for validation state; must be WABISABI_VALIDATION_SIZE bytes.
  *                Pass this to wabisabi_client_handle_response after receiving the issuer response.
  */
 wabisabi_error_t wabisabi_client_create_zero_request(
     const uint8_t* rand_bytes,
-    uint8_t* req_out, int* req_len_out,
+    uint8_t* req_out, int req_out_cap, int* req_len_out,
     uint8_t val_out[WABISABI_VALIDATION_SIZE]);
 
 /**
@@ -166,7 +179,9 @@ wabisabi_error_t wabisabi_client_create_zero_request(
  * amounts       : array of n_amounts int64_t values to request.
  * creds_bytes   : serialized credentials (n_creds × WABISABI_CREDENTIAL_SIZE bytes).
  * rand_bytes    : WABISABI_RAND_SIZE bytes of randomness.
- * req_out       : output buffer; 16 KiB is always sufficient.
+ * req_out       : output buffer for the request (use WABISABI_MAX_REQUEST_SIZE bytes — a real
+ *                 request grows with the range-proof width and can exceed 16 KiB).
+ * req_out_cap   : capacity of req_out in bytes; returns WABISABI_ERR_BUFFER_TOO_SMALL if too small.
  * req_len_out   : set to actual request length on success.
  * val_out       : output buffer for validation state; must be WABISABI_VALIDATION_SIZE bytes.
  */
@@ -176,7 +191,7 @@ wabisabi_error_t wabisabi_client_create_real_request(
     const int64_t* amounts, int n_amounts,
     const uint8_t* creds_bytes, int n_creds,
     const uint8_t* rand_bytes,
-    uint8_t* req_out, int* req_len_out,
+    uint8_t* req_out, int req_out_cap, int* req_len_out,
     uint8_t val_out[WABISABI_VALIDATION_SIZE]);
 
 /**
@@ -187,13 +202,14 @@ wabisabi_error_t wabisabi_client_create_real_request(
  * resp_len      : byte length of resp_bytes.
  * val_bytes     : WABISABI_VALIDATION_SIZE bytes — validation state from the corresponding create call.
  * creds_out     : output buffer (WABISABI_CREDENTIAL_COUNT × WABISABI_CREDENTIAL_SIZE bytes).
+ * creds_out_cap : capacity of creds_out in bytes; returns WABISABI_ERR_BUFFER_TOO_SMALL if too small.
  * n_creds_out   : set to number of credentials on success (always WABISABI_CREDENTIAL_COUNT).
  */
 wabisabi_error_t wabisabi_client_handle_response(
     const uint8_t* iparams_bytes,
     const uint8_t* resp_bytes, int resp_len,
     const uint8_t val_bytes[WABISABI_VALIDATION_SIZE],
-    uint8_t* creds_out, int* n_creds_out);
+    uint8_t* creds_out, int creds_out_cap, int* n_creds_out);
 
 #ifdef __cplusplus
 }

--- a/c/src/ffi.c
+++ b/c/src/ffi.c
@@ -75,6 +75,12 @@ write_proof(uint8_t* buf, const wabisabi_proof_t* p) {
     return off;
 }
 
+/* Serialized size of a proof, in bytes (mirrors write_proof). */
+static int
+proof_serialized_size(const wabisabi_proof_t* p) {
+    return 2 + p->n_nonces * WABISABI_GE_SIZE + p->n_responses * WABISABI_SCALAR_SIZE;
+}
+
 /* Returns bytes consumed, or -1 on error. */
 static int
 read_proof(const uint8_t* buf, int buf_remaining, wabisabi_proof_t* p) {
@@ -139,6 +145,12 @@ write_issuance_request(uint8_t* buf, const wabisabi_issuance_request_t* req) {
         write_ge(buf + off, &req->bit_commitments[i]);
     }
     return off;
+}
+
+/* Serialized size of an issuance request, in bytes (mirrors write_issuance_request). */
+static int
+issuance_request_serialized_size(const wabisabi_issuance_request_t* req) {
+    return WABISABI_GE_SIZE * (1 + req->n_bit_commitments);
 }
 
 /* n_bits must be caller-validated against WABISABI_MAX_RANGE_WIDTH before calling. */
@@ -294,6 +306,12 @@ read_validation_state(const uint8_t* buf, wabisabi_response_validation_t* val) {
  *
  * Returns number of bytes written: 12 + count * WABISABI_GE_SIZE.
  */
+/* Serialized size of the mutable issuer state, in bytes (mirrors write_mutable_state). */
+static int
+mutable_state_serialized_size(const wabisabi_issuer_state_t* issuer) {
+    return 12 + issuer->serial_numbers.count * WABISABI_GE_SIZE;
+}
+
 static int
 write_mutable_state(uint8_t* buf, const wabisabi_issuer_state_t* issuer) {
     int64_t b = issuer->balance;
@@ -419,8 +437,8 @@ wabisabi_issuer_handle_zero(const uint8_t* sk_bytes, int64_t max_amount,
                             const uint8_t* mstate_in, int mstate_in_len,
                             const uint8_t* req_bytes, int req_len,
                             const uint8_t* rand_bytes,
-                            uint8_t* resp_out, int* resp_len_out,
-                            uint8_t* mstate_out, int* mstate_out_len) {
+                            uint8_t* resp_out, int resp_out_cap, int* resp_len_out,
+                            uint8_t* mstate_out, int mstate_out_cap, int* mstate_out_len) {
     if (!sk_bytes || !req_bytes || !rand_bytes || !resp_out || !resp_len_out
         || !mstate_out || !mstate_out_len) {
         return WABISABI_ERR_NULL_PTR;
@@ -459,6 +477,15 @@ wabisabi_issuer_handle_zero(const uint8_t* sk_bytes, int64_t max_amount,
         return err;
     }
 
+    int resp_needed = WABISABI_CREDENTIAL_COUNT * WABISABI_MAC_SIZE;
+    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+        resp_needed += proof_serialized_size(&resp.proofs[i]);
+    }
+    if (resp_out_cap < resp_needed
+        || mstate_out_cap < mutable_state_serialized_size(&issuer)) {
+        return WABISABI_ERR_BUFFER_TOO_SMALL;
+    }
+
     off = 0;
     for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
         off += write_mac(resp_out + off, &resp.issued[i]);
@@ -486,8 +513,8 @@ wabisabi_issuer_handle_real(const uint8_t* sk_bytes, int64_t max_amount,
                             const uint8_t* mstate_in, int mstate_in_len,
                             const uint8_t* req_bytes, int req_len,
                             const uint8_t* rand_bytes,
-                            uint8_t* resp_out, int* resp_len_out,
-                            uint8_t* mstate_out, int* mstate_out_len) {
+                            uint8_t* resp_out, int resp_out_cap, int* resp_len_out,
+                            uint8_t* mstate_out, int mstate_out_cap, int* mstate_out_len) {
     if (!sk_bytes || !req_bytes || !rand_bytes || !resp_out || !resp_len_out
         || !mstate_out || !mstate_out_len) {
         return WABISABI_ERR_NULL_PTR;
@@ -559,6 +586,15 @@ wabisabi_issuer_handle_real(const uint8_t* sk_bytes, int64_t max_amount,
         return err;
     }
 
+    int resp_needed = WABISABI_CREDENTIAL_COUNT * WABISABI_MAC_SIZE;
+    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+        resp_needed += proof_serialized_size(&resp.proofs[i]);
+    }
+    if (resp_out_cap < resp_needed
+        || mstate_out_cap < mutable_state_serialized_size(&issuer)) {
+        return WABISABI_ERR_BUFFER_TOO_SMALL;
+    }
+
     off = 0;
     for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
         off += write_mac(resp_out + off, &resp.issued[i]);
@@ -582,7 +618,7 @@ wabisabi_issuer_handle_real(const uint8_t* sk_bytes, int64_t max_amount,
  */
 wabisabi_error_t
 wabisabi_client_create_zero_request(const uint8_t* rand_bytes,
-                                    uint8_t* req_out, int* req_len_out,
+                                    uint8_t* req_out, int req_out_cap, int* req_len_out,
                                     uint8_t val_out[WABISABI_VALIDATION_SIZE]) {
     if (!rand_bytes || !req_out || !req_len_out || !val_out) {
         return WABISABI_ERR_NULL_PTR;
@@ -597,6 +633,14 @@ wabisabi_client_create_zero_request(const uint8_t* rand_bytes,
     wabisabi_zero_request_t req;
     wabisabi_response_validation_t val;
     wabisabi_client_state_create_zero_request(&client, rand_bytes, &req, &val);
+
+    int req_needed = WABISABI_CREDENTIAL_COUNT * WABISABI_GE_SIZE;
+    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+        req_needed += proof_serialized_size(&req.proofs[i]);
+    }
+    if (req_out_cap < req_needed) {
+        return WABISABI_ERR_BUFFER_TOO_SMALL;
+    }
 
     int off = 0;
     for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
@@ -622,7 +666,7 @@ wabisabi_client_create_real_request(const uint8_t* iparams_bytes, int64_t max_am
                                     const int64_t* amounts, int n_amounts,
                                     const uint8_t* creds_bytes, int n_creds,
                                     const uint8_t* rand_bytes,
-                                    uint8_t* req_out, int* req_len_out,
+                                    uint8_t* req_out, int req_out_cap, int* req_len_out,
                                     uint8_t val_out[WABISABI_VALIDATION_SIZE]) {
     if (!iparams_bytes || !creds_bytes || !rand_bytes || !req_out || !req_len_out || !val_out) {
         return WABISABI_ERR_NULL_PTR;
@@ -657,6 +701,19 @@ wabisabi_client_create_real_request(const uint8_t* iparams_bytes, int64_t max_am
     wabisabi_client_state_create_real_request(&client, amounts, n_amounts, creds, n_creds,
                                               rand_bytes, &req, &val);
     secure_zero(creds, sizeof(creds));
+
+    int req_needed = WABISABI_VALUE_SIZE
+                   + WABISABI_CREDENTIAL_COUNT * WABISABI_PRESENTATION_SIZE
+                   + 1; /* n_proofs byte */
+    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+        req_needed += issuance_request_serialized_size(&req.requested[i]);
+    }
+    for (int i = 0; i < req.n_proofs; i++) {
+        req_needed += proof_serialized_size(&req.proofs[i]);
+    }
+    if (req_out_cap < req_needed) {
+        return WABISABI_ERR_BUFFER_TOO_SMALL;
+    }
 
     int off = 0;
 
@@ -694,7 +751,7 @@ wabisabi_error_t
 wabisabi_client_handle_response(const uint8_t* iparams_bytes,
                                 const uint8_t* resp_bytes, int resp_len,
                                 const uint8_t val_bytes[WABISABI_VALIDATION_SIZE],
-                                uint8_t* creds_out, int* n_creds_out) {
+                                uint8_t* creds_out, int creds_out_cap, int* n_creds_out) {
     if (!iparams_bytes || !resp_bytes || !val_bytes || !creds_out || !n_creds_out) {
         return WABISABI_ERR_NULL_PTR;
     }
@@ -702,6 +759,9 @@ wabisabi_client_handle_response(const uint8_t* iparams_bytes,
     int min_len = WABISABI_CREDENTIAL_COUNT * WABISABI_MAC_SIZE;
     if (resp_len < min_len) {
         return WABISABI_ERR_INVALID_LENGTH;
+    }
+    if (creds_out_cap < WABISABI_CREDENTIAL_COUNT * WABISABI_CREDENTIAL_SIZE) {
+        return WABISABI_ERR_BUFFER_TOO_SMALL;
     }
 
     wabisabi_iparams_t ip;

--- a/csharp/WabiSabi/Native/CredentialIssuer.cs
+++ b/csharp/WabiSabi/Native/CredentialIssuer.cs
@@ -70,7 +70,7 @@ public class CredentialIssuer
         var rand    = new byte[NativeWabi.RandSize];
         _rng.GetBytes(rand);
 
-        var respOut = new byte[16 * 1024];
+        var respOut = new byte[NativeWabi.MaxRequestSize];
 
         lock (_lock)
         {
@@ -81,15 +81,15 @@ public class CredentialIssuer
                     _currentMstate, _currentMstate.Length,
                     reqBytes, reqBytes.Length,
                     rand,
-                    respOut, out respLen,
-                    _mstateOutBuf, out mstateOutLen)
+                    respOut, respOut.Length, out respLen,
+                    _mstateOutBuf, _mstateOutBuf.Length, out mstateOutLen)
                 : NativeWabi.IssuerHandleReal(
                     _skBytes, MaxAmount,
                     _currentMstate, _currentMstate.Length,
                     reqBytes, reqBytes.Length,
                     rand,
-                    respOut, out respLen,
-                    _mstateOutBuf, out mstateOutLen);
+                    respOut, respOut.Length, out respLen,
+                    _mstateOutBuf, _mstateOutBuf.Length, out mstateOutLen);
 
             if (rc != 0)
                 throw new WabiSabiCryptoException(

--- a/csharp/WabiSabi/Native/NativeWabi.cs
+++ b/csharp/WabiSabi/Native/NativeWabi.cs
@@ -50,6 +50,14 @@ internal static class NativeWabi
     /// <summary>Maximum size of the serialized mutable issuer state in bytes.</summary>
     public const int IssuerMStateMaxSize = 8 + 4 + IssuerMaxSerials * GeSize;
 
+    /// <summary>
+    /// Recommended size (and upper bound) for request/response output buffers, mirroring
+    /// the C <c>WABISABI_MAX_REQUEST_SIZE</c>. A real request grows with the range-proof
+    /// width (≈21 KiB at the maximum width), so the legacy 16 KiB is NOT enough — a large
+    /// <c>maxAmount</c> would overrun it. 64 KiB is always sufficient.
+    /// </summary>
+    public const int MaxRequestSize = 64 * 1024;
+
     // ---- Initialization ----
 
     [DllImport(Lib, EntryPoint = "wabisabi_init", CallingConvention = CallingConvention.Cdecl)]
@@ -88,8 +96,8 @@ internal static class NativeWabi
         [In] byte[] mstateIn, int mstateInLen,
         [In] byte[] reqBytes, int reqLen,
         [In] byte[] randBytes,
-        [Out] byte[] respOut, out int respLenOut,
-        [Out] byte[] mstateOut, out int mstateOutLen);
+        [Out] byte[] respOut, int respOutCap, out int respLenOut,
+        [Out] byte[] mstateOut, int mstateOutCap, out int mstateOutLen);
 
     /// <summary>Process a real credential request. Same parameters as IssuerHandleZero.</summary>
     [DllImport(Lib, EntryPoint = "wabisabi_issuer_handle_real", CallingConvention = CallingConvention.Cdecl)]
@@ -99,8 +107,8 @@ internal static class NativeWabi
         [In] byte[] mstateIn, int mstateInLen,
         [In] byte[] reqBytes, int reqLen,
         [In] byte[] randBytes,
-        [Out] byte[] respOut, out int respLenOut,
-        [Out] byte[] mstateOut, out int mstateOutLen);
+        [Out] byte[] respOut, int respOutCap, out int respLenOut,
+        [Out] byte[] mstateOut, int mstateOutCap, out int mstateOutLen);
 
     // ---- Client (stateless) ----
 
@@ -114,7 +122,7 @@ internal static class NativeWabi
     [DllImport(Lib, EntryPoint = "wabisabi_client_create_zero_request", CallingConvention = CallingConvention.Cdecl)]
     public static extern int ClientCreateZeroRequest(
         [In] byte[] randBytes,
-        [Out] byte[] reqOut, out int reqLenOut,
+        [Out] byte[] reqOut, int reqOutCap, out int reqLenOut,
         [Out] byte[] valOut);
 
     /// <summary>
@@ -137,7 +145,7 @@ internal static class NativeWabi
         [In] long[] amounts, int nAmounts,
         [In] byte[] credsBytes, int nCreds,
         [In] byte[] randBytes,
-        [Out] byte[] reqOut, out int reqLenOut,
+        [Out] byte[] reqOut, int reqOutCap, out int reqLenOut,
         [Out] byte[] valOut);
 
     /// <summary>
@@ -154,5 +162,5 @@ internal static class NativeWabi
         [In] byte[] iparamsBytes,
         [In] byte[] respBytes, int respLen,
         [In] byte[] valBytes,
-        [Out] byte[] credsOut, out int nCredsOut);
+        [Out] byte[] credsOut, int credsOutCap, out int nCredsOut);
 }

--- a/csharp/WabiSabi/Native/WabiSabiClient.cs
+++ b/csharp/WabiSabi/Native/WabiSabiClient.cs
@@ -55,10 +55,10 @@ public class WabiSabiClient
         var rand   = new byte[NativeWabi.RandSize];
         _rng.GetBytes(rand);
 
-        var reqOut = new byte[16 * 1024];
+        var reqOut = new byte[NativeWabi.MaxRequestSize];
         var valOut = new byte[NativeWabi.ValidationSize];
         int reqLen;
-        int rc = NativeWabi.ClientCreateZeroRequest(rand, reqOut, out reqLen, valOut);
+        int rc = NativeWabi.ClientCreateZeroRequest(rand, reqOut, reqOut.Length, out reqLen, valOut);
         if (rc != 0)
             throw new WabiSabiCryptoException(
                 WabiSabiCryptoErrorCode.ClientReceivedInvalidProofs,
@@ -103,7 +103,7 @@ public class WabiSabiClient
         var rand   = new byte[NativeWabi.RandSize];
         _rng.GetBytes(rand);
 
-        var reqOut = new byte[16 * 1024];
+        var reqOut = new byte[NativeWabi.MaxRequestSize];
         var valOut = new byte[NativeWabi.ValidationSize];
         int reqLen;
         int rc = NativeWabi.ClientCreateRealRequest(
@@ -112,7 +112,7 @@ public class WabiSabiClient
             amounts.ToArray(), amounts.Count,
             credsBytes, credsList.Length,
             rand,
-            reqOut, out reqLen,
+            reqOut, reqOut.Length, out reqLen,
             valOut);
 
         if (rc != 0)
@@ -161,7 +161,7 @@ public class WabiSabiClient
             _iparamsBytes,
             respBytes, respBytes.Length,
             valBytes,
-            credsOut, out nCreds);
+            credsOut, credsOut.Length, out nCreds);
 
         if (rc != 0)
             throw new WabiSabiCryptoException(

--- a/interop/WabiSabiInterop.Tests/BinaryCompatibilityTests.cs
+++ b/interop/WabiSabiInterop.Tests/BinaryCompatibilityTests.cs
@@ -198,10 +198,10 @@ public class BinaryCompatibilityTests
 
         // Use the stateless C API directly to hold the raw credential bytes.
         var clientRand = ChainRng("cred-native-client").GetBytes(NativeWabi.RandSize);
-        var reqOut     = new byte[16 * 1024];
+        var reqOut     = new byte[NativeWabi.MaxRequestSize];
         var valOut     = new byte[NativeWabi.ValidationSize];
         int reqLen;
-        Assert.Equal(0, NativeWabi.ClientCreateZeroRequest(clientRand, reqOut, out reqLen, valOut));
+        Assert.Equal(0, NativeWabi.ClientCreateZeroRequest(clientRand, reqOut, reqOut.Length, out reqLen, valOut));
 
         // C# issuer processes the native zero request.
         var nativeZeroReq = WireFormat.DeserializeZeroRequest(reqOut[..reqLen]);
@@ -213,7 +213,7 @@ public class BinaryCompatibilityTests
         var credBuffer = new byte[NativeWabi.CredentialCount * NativeWabi.CredentialSize];
         int nCreds;
         Assert.Equal(0, NativeWabi.ClientHandleResponse(
-            FixedIparamsBytes, respBytes, respBytes.Length, valOut, credBuffer, out nCreds));
+            FixedIparamsBytes, respBytes, respBytes.Length, valOut, credBuffer, credBuffer.Length, out nCreds));
         Assert.Equal(NativeWabi.CredentialCount, nCreds);
 
         // C# WireFormat parses the raw C bytes, then re-serialises them.

--- a/interop/WabiSabiInterop.Tests/LargeRangeWidthTests.cs
+++ b/interop/WabiSabiInterop.Tests/LargeRangeWidthTests.cs
@@ -1,0 +1,83 @@
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using WabiSabi.Crypto;
+using Xunit;
+using NativeClient = WabiSabi.Native.WabiSabiClient;
+using CsClient     = WabiSabi.Crypto.WabiSabiClient;
+using CsIssuer     = WabiSabi.Crypto.CredentialIssuer;
+using NativeIssuer = WabiSabi.Native.CredentialIssuer;
+
+namespace WabiSabiInterop.Tests;
+
+/// <summary>
+/// Regression guard for the FFI output-buffer overflow: a real credential request
+/// grows with the range-proof width. WalletWasabi's coordinator uses
+/// MaxRegistrableAmount = 43,000 BTC (width 42), whose real request is ~17.6 KiB and
+/// overran the old fixed 16 KiB native reqOut/respOut buffers — crashing the process.
+/// These exercise the full protocol through the native client AND native issuer at
+/// that width; they must not crash and must round-trip the credential values.
+/// </summary>
+[Collection("NativeLibrary")]
+public class LargeRangeWidthTests
+{
+    // 43,000 BTC in satoshis — the WalletWasabi default MaxRegistrableAmount (width 42).
+    private const long WalletWasabiMaxAmount = 4_300_000_000_000L;
+    private static readonly long[] Amounts = { 500_000L, 300_000L };
+
+    [Fact]
+    public void FullProtocol_NativeClient_CSharpIssuer_AtWalletWasabiWidth()
+    {
+        var sk      = new CredentialIssuerSecretKey(ChainRng("lrw-cs-sk"));
+        var iparams = sk.ComputeCredentialIssuerParameters();
+
+        var client = new NativeClient(iparams, ChainRng("lrw-native-client"), WalletWasabiMaxAmount);
+        var issuer = new CsIssuer(sk, ChainRng("lrw-cs-issuer"), WalletWasabiMaxAmount);
+
+        var zero      = client.CreateRequestForZeroAmount();
+        var zeroResp  = issuer.HandleRequest(WireRoundTripZero(zero.CredentialsRequest));
+        var zeroCreds = client.HandleResponse(zeroResp, zero.CredentialsResponseValidation).ToArray();
+
+        var real      = client.CreateRequest(Amounts, zeroCreds, CancellationToken.None);
+        var realResp  = issuer.HandleRequest(real.CredentialsRequest);
+        var creds     = client.HandleResponse(realResp, real.CredentialsResponseValidation).ToArray();
+
+        Assert.Equal(2, creds.Length);
+        Assert.Equal(Amounts.Sum(), creds.Sum(c => c.Value));
+    }
+
+    [Fact]
+    public void FullProtocol_CSharpClient_NativeIssuer_AtWalletWasabiWidth()
+    {
+        var sk      = new CredentialIssuerSecretKey(ChainRng("lrw2-cs-sk"));
+        var iparams = sk.ComputeCredentialIssuerParameters();
+
+        var client = new CsClient(iparams, ChainRng("lrw2-cs-client"), WalletWasabiMaxAmount);
+        var issuer = new NativeIssuer(sk, ChainRng("lrw2-native-issuer"), WalletWasabiMaxAmount);
+
+        var zero      = client.CreateRequestForZeroAmount();
+        var zeroResp  = issuer.HandleRequest(zero.CredentialsRequest);
+        var zeroCreds = client.HandleResponse(zeroResp, zero.CredentialsResponseValidation).ToArray();
+
+        var real      = client.CreateRequest(Amounts, zeroCreds, CancellationToken.None);
+        var realResp  = issuer.HandleRequest(real.CredentialsRequest);
+        var creds     = client.HandleResponse(realResp, real.CredentialsResponseValidation).ToArray();
+
+        Assert.Equal(2, creds.Length);
+        Assert.Equal(Amounts.Sum(), creds.Sum(c => c.Value));
+    }
+
+    // The native client emits a ZeroCredentialsRequest; round-trip it through the wire
+    // so the C# issuer receives exactly the serialized form (mirrors the existing suite).
+    private static WabiSabi.CredentialRequesting.ZeroCredentialsRequest WireRoundTripZero(
+        WabiSabi.CredentialRequesting.ICredentialsRequest req)
+    {
+        var bytes = WabiSabi.Native.WireFormat.SerializeZeroRequest(
+            (WabiSabi.CredentialRequesting.ZeroCredentialsRequest)req);
+        return WabiSabi.Native.WireFormat.DeserializeZeroRequest(bytes);
+    }
+
+    private static Sha256ChainRandom ChainRng(string label) =>
+        new(SHA256.HashData(Encoding.ASCII.GetBytes(label)));
+}


### PR DESCRIPTION
The native P/Invoke wrappers passed fixed 16 KiB output buffers to the C library with no capacity argument, so the C side could never bounds-check. A real credential request grows with the range-proof width: WalletWasabi's coordinator uses MaxRegistrableAmount = 43,000 BTC (width 42), whose request is ~17.6 KiB. That overran the 16 KiB reqOut buffer, corrupting the heap and crashing the host process (observed as a SIGSEGV killing the test host in BobClientTests.RegisterOutputTestAsync). The interop suite only ever exercised width 20 (~9 KiB), so it never hit the overflow.

Close the whole class of bug rather than just bumping one buffer:

- Add a capacity (*_cap) parameter to every output-buffer FFI function and a new WABISABI_ERR_BUFFER_TOO_SMALL error code. The C side now computes the exact serialized size and returns the error instead of overrunning.
- Add WABISABI_MAX_REQUEST_SIZE (64 KiB) — always sufficient up to the maximum range-proof width — and size the managed buffers to it, passing .Length as the cap on every call.
- Correct the "16 KiB is always sufficient" docs in wabisabi_ffi.h.

Add LargeRangeWidthTests covering the full protocol at width 42 in both directions (the NativeClient -> C# issuer case reproduces the crash).

C 127/127, managed 125/125, interop 12/12.