### PR TITLE
Fix native proof generation/verification not being thread-safe

### DIFF
--- a/c/src/proof.c
+++ b/c/src/proof.c
@@ -55,12 +55,21 @@ compute_public_nonce(wabisabi_ge_t* out, const wabisabi_equation_t* eq, const wa
 void
 wabisabi_prove(wabisabi_proof_t* out, wabisabi_transcript_t* transcript, const wabisabi_knowledge_t* knowledge, int n,
                const uint8_t* random_bytes, size_t rnd_len) {
+    /* Scratch for the dense generator matrix. Heap-allocated (≈1.7 MB) rather
+     * than a function-local `static` so that wabisabi_prove is reentrant /
+     * thread-safe: concurrent callers must not share this buffer. Too large for
+     * the stack (would overflow small worker-thread stacks). */
+    wabisabi_ge_t* gens = malloc((size_t)PROOF_MAX_EQUATIONS * PROOF_MAX_WITNESSES * sizeof(wabisabi_ge_t));
+    if (!gens) {
+        return;
+    }
+
     /* Step 1: commit all statements to transcript */
     for (int k = 0; k < n; k++) {
         const wabisabi_statement_t* stmt = &knowledge[k].statement;
 
         /* Collect all public points from equations */
-        static wabisabi_ge_t pub_pts[PROOF_MAX_EQUATIONS];
+        wabisabi_ge_t pub_pts[PROOF_MAX_EQUATIONS];
         int n_pub = 0;
         for (int e = 0; e < stmt->n_equations; e++) {
             pub_pts[n_pub++] = stmt->equations[e].public_point;
@@ -72,7 +81,6 @@ wabisabi_prove(wabisabi_proof_t* out, wabisabi_transcript_t* transcript, const w
          * equations × witnesses densely. For sparse, we expand to dense
          * for the transcript only.
          */
-        static wabisabi_ge_t gens[PROOF_MAX_EQUATIONS * PROOF_MAX_WITNESSES];
         int n_gen = 0;
         for (int e = 0; e < stmt->n_equations; e++) {
             /* Build dense row from sparse entries */
@@ -91,9 +99,11 @@ wabisabi_prove(wabisabi_proof_t* out, wabisabi_transcript_t* transcript, const w
         wabisabi_transcript_commit_statement(transcript, pub_pts, n_pub, gens, n_gen);
     }
 
+    free(gens);
+
     /* Step 2: for each knowledge, generate secret nonces and public nonces */
-    static wabisabi_scalar_t all_secret_nonces[PROOF_MAX_WITNESSES];
-    static wabisabi_ge_t all_public_nonces[PROOF_MAX_EQUATIONS];
+    wabisabi_scalar_t all_secret_nonces[PROOF_MAX_WITNESSES];
+    wabisabi_ge_t all_public_nonces[PROOF_MAX_EQUATIONS];
 
     for (int k = 0; k < n; k++) {
         const wabisabi_knowledge_t* kn = &knowledge[k];
@@ -147,11 +157,18 @@ wabisabi_verify(wabisabi_transcript_t* transcript, const wabisabi_statement_t* s
         return 0;
     }
 
+    /* Scratch for the dense generator matrix. Heap-allocated (≈1.7 MB) rather
+     * than a function-local `static` so that wabisabi_verify is reentrant /
+     * thread-safe: concurrent callers must not share this buffer. */
+    wabisabi_ge_t* gens = malloc((size_t)PROOF_MAX_EQUATIONS * PROOF_MAX_WITNESSES * sizeof(wabisabi_ge_t));
+    if (!gens) {
+        return 0;
+    }
+
     /* Step 1: commit all statements (same as in prove) */
     for (int k = 0; k < n_stmt; k++) {
         const wabisabi_statement_t* stmt = &statements[k];
-        static wabisabi_ge_t pub_pts[PROOF_MAX_EQUATIONS];
-        static wabisabi_ge_t gens[PROOF_MAX_EQUATIONS * PROOF_MAX_WITNESSES];
+        wabisabi_ge_t pub_pts[PROOF_MAX_EQUATIONS];
         int n_pub = 0, n_gen = 0;
         for (int e = 0; e < stmt->n_equations; e++) {
             pub_pts[n_pub++] = stmt->equations[e].public_point;
@@ -170,6 +187,8 @@ wabisabi_verify(wabisabi_transcript_t* transcript, const wabisabi_statement_t* s
         }
         wabisabi_transcript_commit_statement(transcript, pub_pts, n_pub, gens, n_gen);
     }
+
+    free(gens);
 
     /* Step 2: commit all public nonces */
     for (int k = 0; k < n_proof; k++) {
@@ -210,7 +229,7 @@ wabisabi_pedersen_commit(wabisabi_ge_t* out, const wabisabi_scalar_t* amount, co
 wabisabi_statement_t
 wabisabi_issuer_params_statement(const wabisabi_iparams_t* iparams, const wabisabi_mac_t* mac,
                                   const wabisabi_ge_t* ma) {
-    static wabisabi_statement_t stmt;
+    wabisabi_statement_t stmt;
     memset(&stmt, 0, sizeof(stmt));
     stmt.n_equations = 3;
     stmt.n_witnesses = 5; /* w, wp, x0, x1, ya */
@@ -318,7 +337,7 @@ wabisabi_credential_present(const wabisabi_mac_t* mac, int64_t value, const wabi
 wabisabi_statement_t
 wabisabi_show_credential_statement(const wabisabi_presentation_t* p, const wabisabi_ge_t* z_point,
                                    const wabisabi_iparams_t* iparams) {
-    static wabisabi_statement_t stmt;
+    wabisabi_statement_t stmt;
     memset(&stmt, 0, sizeof(stmt));
     stmt.n_equations = 4;
     stmt.n_witnesses = 5; /* z, z0=-t*z, t, a, r */
@@ -358,7 +377,7 @@ wabisabi_show_credential_knowledge(const wabisabi_presentation_t* p, const wabis
     wabisabi_ge_t z_point;
     wabisabi_ge_mul(&z_point, z, &iparams->i);
 
-    static wabisabi_knowledge_t kn;
+    wabisabi_knowledge_t kn;
     kn.statement = wabisabi_show_credential_statement(p, &z_point, iparams);
 
     /* Witness: (z, z0 = -(t*z), t, a, r) */
@@ -388,7 +407,7 @@ wabisabi_show_credential_knowledge(const wabisabi_presentation_t* p, const wabis
 
 wabisabi_statement_t
 wabisabi_balance_proof_statement(const wabisabi_ge_t* balance_commitment) {
-    static wabisabi_statement_t stmt;
+    wabisabi_statement_t stmt;
     memset(&stmt, 0, sizeof(stmt));
     stmt.n_equations = 1;
     stmt.n_witnesses = 2; /* z_sum, r_delta_sum */
@@ -404,7 +423,7 @@ wabisabi_balance_proof_statement(const wabisabi_ge_t* balance_commitment) {
 wabisabi_knowledge_t
 wabisabi_balance_proof_knowledge(const wabisabi_scalar_t* z_sum, const wabisabi_scalar_t* r_delta_sum) {
     /* Balance commitment = z_sum*Ga + r_delta_sum*Gh */
-    static wabisabi_knowledge_t kn;
+    wabisabi_knowledge_t kn;
 
     wabisabi_ge_t zGa, rGh;
     wabisabi_ge_mul(&zGa, z_sum, &WABISABI_Ga);
@@ -427,7 +446,7 @@ wabisabi_zero_proof_statement(const wabisabi_ge_t* ma) {
 
 wabisabi_knowledge_t
 wabisabi_zero_proof_knowledge(const wabisabi_ge_t* ma, const wabisabi_scalar_t* r) {
-    static wabisabi_knowledge_t kn;
+    wabisabi_knowledge_t kn;
     kn.statement = wabisabi_zero_proof_statement(ma);
     kn.witness[0] = *r;
     return kn;
@@ -439,7 +458,7 @@ wabisabi_statement_t
 wabisabi_range_proof_statement(const wabisabi_ge_t* ma, const wabisabi_ge_t* bit_commitments, int width) {
     assert(width >= 0 && width <= WABISABI_MAX_RANGE_WIDTH);
 
-    static wabisabi_statement_t stmt;
+    wabisabi_statement_t stmt;
     memset(&stmt, 0, sizeof(stmt));
 
     /* rows = 2*width + 1 (or 1 if width==0) */
@@ -509,7 +528,7 @@ wabisabi_range_proof_knowledge(const wabisabi_scalar_t* amount, const wabisabi_s
                                const uint8_t* random_bytes, size_t rnd_len) {
     assert(width >= 0 && width <= WABISABI_MAX_RANGE_WIDTH);
 
-    static wabisabi_range_proof_t rp;
+    wabisabi_range_proof_t rp;
     rp.width = width;
 
     wabisabi_ge_t ma;

--- a/interop/WabiSabiInterop.Tests/ConcurrencyTests.cs
+++ b/interop/WabiSabiInterop.Tests/ConcurrencyTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WabiSabi.Crypto;
+using WabiSabi.Crypto.Randomness;
+using Xunit;
+using NativeClient = WabiSabi.Native.WabiSabiClient;
+using CsIssuer     = WabiSabi.Crypto.CredentialIssuer;
+
+namespace WabiSabiInterop.Tests;
+
+/// <summary>Thread-safe RNG (RandomNumberGenerator is thread-safe), matching how
+/// WalletWasabi shares one thread-safe RNG across concurrent Alices.</summary>
+internal sealed class ThreadSafeRandom : WasabiRandom
+{
+    public override void GetBytes(byte[] output) => RandomNumberGenerator.Fill(output);
+    public override void GetBytes(Span<byte> output) => RandomNumberGenerator.Fill(output);
+    public override int GetInt(int fromInclusive, int toExclusive) =>
+        RandomNumberGenerator.GetInt32(fromInclusive, toExclusive);
+}
+
+/// <summary>
+/// Regression guard for the native proof-generation thread-safety bug. The C proof
+/// code (proof.c) used function-local <c>static</c> scratch buffers shared across all
+/// threads; concurrent prove/verify calls clobbered each other and produced invalid
+/// proofs that the C# issuer rejected with <c>CoordinatorReceivedInvalidProofs</c>.
+///
+/// This reproduced in WalletWasabi because two Alices share one ArenaClient (one native
+/// amount client) and run their input-registration + confirmation flows concurrently.
+/// The race is process-global (it reproduces even with separate client instances), so
+/// these tests drive many concurrent full-protocol flows and assert every one succeeds.
+/// </summary>
+[Collection("NativeLibrary")]
+public class ConcurrencyTests
+{
+    private const long WalletWasabiMaxAmount = 4_300_000_000_000L; // width 42
+
+    private static Sha256ChainRandom ChainRng(string label) =>
+        new(SHA256.HashData(Encoding.ASCII.GetBytes(label)));
+
+    // One full confirmation-style flow: native client presents bootstrap zero
+    // credentials and requests `amount`, verified by a C# issuer.
+    private static long RunFlow(NativeClient client, CsIssuer issuer, long amount)
+    {
+        var zero      = client.CreateRequestForZeroAmount();
+        var zeroResp  = issuer.HandleRequest(zero.CredentialsRequest);
+        var zeroCreds = client.HandleResponse(zeroResp, zero.CredentialsResponseValidation).ToArray();
+
+        var real      = client.CreateRequest(new[] { amount, 0L }, zeroCreds, CancellationToken.None);
+        var realResp  = issuer.HandleRequest(real.CredentialsRequest);
+        var creds     = client.HandleResponse(realResp, real.CredentialsResponseValidation).ToArray();
+        return creds.Sum(c => c.Value);
+    }
+
+    // Shared client instance across concurrent flows — mirrors WalletWasabi's ArenaClient.
+    [Fact]
+    public async Task SharedClient_ManyConcurrentFlows_AllProofsValid()
+    {
+        var sk      = new CredentialIssuerSecretKey(ChainRng("conc-shared-sk"));
+        var iparams = sk.ComputeCredentialIssuerParameters();
+        var client  = new NativeClient(iparams, new ThreadSafeRandom(), WalletWasabiMaxAmount);
+        var issuer  = new CsIssuer(sk, ChainRng("conc-shared-issuer"), WalletWasabiMaxAmount);
+
+        var amounts = Enumerable.Range(1, 16).Select(i => (long)i * 100_000_000L).ToArray();
+        var tasks = amounts.Select(a => Task.Run(() => RunFlow(client, issuer, a))).ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        Assert.Equal(amounts, results);
+    }
+
+    // Separate client instances, still concurrent — proves the fixed scratch is not
+    // process-global shared state anymore.
+    [Fact]
+    public async Task SeparateClients_ManyConcurrentFlows_AllProofsValid()
+    {
+        var sk      = new CredentialIssuerSecretKey(ChainRng("conc-sep-sk"));
+        var iparams = sk.ComputeCredentialIssuerParameters();
+        var issuer  = new CsIssuer(sk, ChainRng("conc-sep-issuer"), WalletWasabiMaxAmount);
+
+        long Flow(int i)
+        {
+            var client = new NativeClient(iparams, ChainRng($"conc-sep-client-{i}"), WalletWasabiMaxAmount);
+            return RunFlow(client, issuer, (long)i * 100_000_000L);
+        }
+
+        var tasks = Enumerable.Range(1, 16).Select(i => Task.Run(() => Flow(i))).ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        Assert.Equal(Enumerable.Range(1, 16).Select(i => (long)i * 100_000_000L), results);
+    }
+}

--- a/interop/WabiSabiInterop.Tests/LargeRangeWidthTests.cs
+++ b/interop/WabiSabiInterop.Tests/LargeRangeWidthTests.cs
@@ -47,6 +47,34 @@ public class LargeRangeWidthTests
         Assert.Equal(Amounts.Sum(), creds.Sum(c => c.Value));
     }
 
+    // Mirrors the WalletWasabi confirmation flow: present zero credentials and request
+    // the real coin value (1 BTC / 2 BTC). These values set high range-proof bits (~27)
+    // that the {500k,300k} test above never touches.
+    [Theory]
+    [InlineData(100_000_000L, 0L)]
+    [InlineData(100_000_000L, 200_000_000L)]
+    [InlineData(4_299_999_999_999L, 0L)]
+    public void FullProtocol_NativeClient_CSharpIssuer_LargeValues(long a0, long a1)
+    {
+        var amounts = new[] { a0, a1 };
+        var sk      = new CredentialIssuerSecretKey(ChainRng("lrwhv-cs-sk"));
+        var iparams = sk.ComputeCredentialIssuerParameters();
+
+        var client = new NativeClient(iparams, ChainRng("lrwhv-native-client"), WalletWasabiMaxAmount);
+        var issuer = new CsIssuer(sk, ChainRng("lrwhv-cs-issuer"), WalletWasabiMaxAmount);
+
+        var zero      = client.CreateRequestForZeroAmount();
+        var zeroResp  = issuer.HandleRequest(WireRoundTripZero(zero.CredentialsRequest));
+        var zeroCreds = client.HandleResponse(zeroResp, zero.CredentialsResponseValidation).ToArray();
+
+        var real      = client.CreateRequest(amounts, zeroCreds, CancellationToken.None);
+        var realResp  = issuer.HandleRequest(real.CredentialsRequest);
+        var creds     = client.HandleResponse(realResp, real.CredentialsResponseValidation).ToArray();
+
+        Assert.Equal(2, creds.Length);
+        Assert.Equal(amounts.Sum(), creds.Sum(c => c.Value));
+    }
+
     [Fact]
     public void FullProtocol_CSharpClient_NativeIssuer_AtWalletWasabiWidth()
     {


### PR DESCRIPTION
proof.c used function-local `static` scratch buffers (the dense generator matrix `gens`, plus `pub_pts`/`all_secret_nonces`/`all_public_nonces` and the by-value `stmt`/`kn`/`rp` helpers). Function-local `static` means a single copy shared across all threads, so concurrent wabisabi_prove / wabisabi_verify calls clobbered each other's scratch and produced invalid proofs.

This surfaced in WalletWasabi: two Alices share one ArenaClient (hence one native amount-credential client) and run input-registration + connection confirmation concurrently. The corrupted proofs were rejected by the C# issuer with CoordinatorReceivedInvalidProofs, failing StepOutputRegistration and FullP2trCoinjoin tests. The race is process-global — it reproduces even with separate client instances.

Make the proof paths reentrant:
  - Heap-allocate the large (~1.7 MB) `gens` matrix per call (too big for the stack; `_Thread_local` is unsafe in a dlopen'd .so due to static-TLS limits). Freed on all exit paths.
  - Demote the small per-call buffers and the by-value statement/knowledge/ range-proof scratch to ordinary locals (NRVO writes the by-value returns straight into the caller's heap slot at -O2, so no large stack frames).

Add interop regression tests: ConcurrencyTests drives many concurrent full-protocol flows (shared and separate clients) and asserts every proof verifies; LargeRangeWidthTests gains high-value cases (1/2 BTC and near-top) that exercise the upper range-proof bits.

Verified: C unit tests 127/127, managed 125/125, interop 17/17, and the previously-failing WalletWasabi RegisterOutputTestAsync, FullP2trCoinjoinTestAsync and StepOutputRegistration (6) all pass against the rebuilt native lib.