### PR TITLE
Support presentation-only requests in the native FFI

### DIFF
--- a/c/include/wabisabi_ffi.h
+++ b/c/include/wabisabi_ffi.h
@@ -14,8 +14,13 @@
  *
  *   ZeroRequest  : [Ma_0][Ma_1][proof_0][proof_1]
  *   RealRequest  : [delta:VALUE_SIZE][pres_0:PRESENTATION_SIZE][pres_1:PRESENTATION_SIZE]
- *                  [req_0][req_1][n_proofs:1][proofs...]
- *   Response     : [mac_0:MAC_SIZE][mac_1:MAC_SIZE][proof_0][proof_1]
+ *                  [n_requested:1][req_0]...[req_{n-1}][n_proofs:1][proofs...]
+ *                  n_requested is 0 for a presentation-only request (output
+ *                  registration: presents credentials, requests none) or
+ *                  WABISABI_CREDENTIAL_COUNT for a normal request.
+ *   Response     : [n_issued:1][mac_0]...[mac_{n-1}][proof_0]...[proof_{n-1}]
+ *                  n_issued matches the request's n_requested (0 issued
+ *                  credentials for a presentation-only request).
  *
  *   ValidationState (WABISABI_VALIDATION_SIZE bytes):
  *     [strobe_state:200][strobe_pos:1][strobe_pos_begin:1][strobe_cur_flags:1]

--- a/c/src/client.c
+++ b/c/src/client.c
@@ -211,6 +211,9 @@ internal_create_real(wabisabi_client_state_t* c, const int64_t* amounts_to_reque
     }
 
     out_req->delta = total_requested - total_presented;
+    /* The C client always requests the full set of credentials (zero-padded);
+     * it does not emit presentation-only requests. */
+    out_req->n_requested = WABISABI_CREDENTIAL_COUNT;
     out_req->n_proofs = n_knowledge;
 
     /* Build and advance the prove transcript */
@@ -254,9 +257,12 @@ wabisabi_error_t
 wabisabi_client_state_handle_response(wabisabi_client_state_t* c, const wabisabi_response_t* response,
                                       const wabisabi_response_validation_t* val,
                                       wabisabi_credential_t out_credentials[WABISABI_CREDENTIAL_COUNT]) {
+    /* A presentation-only request issues no credentials and carries no proofs. */
+    int n = response->n_issued;
+
     /* Verify issuer parameter proofs */
     wabisabi_statement_t* statements = malloc(WABISABI_CREDENTIAL_COUNT * sizeof(wabisabi_statement_t));
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    for (int i = 0; i < n; i++) {
         statements[i] = wabisabi_issuer_params_statement(&c->iparams, &response->issued[i], &val->requested[i].ma);
     }
 
@@ -264,8 +270,7 @@ wabisabi_client_state_handle_response(wabisabi_client_state_t* c, const wabisabi
     wabisabi_transcript_t verify_transcript;
     wabisabi_transcript_clone(&verify_transcript, &val->transcript);
 
-    if (!wabisabi_verify(&verify_transcript, statements, WABISABI_CREDENTIAL_COUNT, response->proofs,
-                         WABISABI_CREDENTIAL_COUNT)) {
+    if (!wabisabi_verify(&verify_transcript, statements, n, response->proofs, n)) {
         free(statements);
         return WABISABI_ERR_INVALID_PROOF;
     }
@@ -273,7 +278,7 @@ wabisabi_client_state_handle_response(wabisabi_client_state_t* c, const wabisabi
     free(statements);
 
     /* Build credentials from issued MACs */
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    for (int i = 0; i < n; i++) {
         out_credentials[i].value = val->requested[i].value;
         out_credentials[i].randomness = val->requested[i].randomness;
         out_credentials[i].mac = response->issued[i];

--- a/c/src/ffi.c
+++ b/c/src/ffi.c
@@ -477,8 +477,8 @@ wabisabi_issuer_handle_zero(const uint8_t* sk_bytes, int64_t max_amount,
         return err;
     }
 
-    int resp_needed = WABISABI_CREDENTIAL_COUNT * WABISABI_MAC_SIZE;
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    int resp_needed = 1 + resp.n_issued * WABISABI_MAC_SIZE;
+    for (int i = 0; i < resp.n_issued; i++) {
         resp_needed += proof_serialized_size(&resp.proofs[i]);
     }
     if (resp_out_cap < resp_needed
@@ -487,10 +487,11 @@ wabisabi_issuer_handle_zero(const uint8_t* sk_bytes, int64_t max_amount,
     }
 
     off = 0;
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    resp_out[off++] = (uint8_t)resp.n_issued;
+    for (int i = 0; i < resp.n_issued; i++) {
         off += write_mac(resp_out + off, &resp.issued[i]);
     }
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    for (int i = 0; i < resp.n_issued; i++) {
         int n = write_proof(resp_out + off, &resp.proofs[i]);
         if (n < 0) return WABISABI_ERR_PARSE;
         off += n;
@@ -520,7 +521,9 @@ wabisabi_issuer_handle_real(const uint8_t* sk_bytes, int64_t max_amount,
         return WABISABI_ERR_NULL_PTR;
     }
 
-    int min_len = WABISABI_VALUE_SIZE + 2 * WABISABI_PRESENTATION_SIZE + 2 * WABISABI_GE_SIZE + 1;
+    /* delta + presentations + n_requested byte + n_proofs byte (a
+     * presentation-only request carries no issuance requests). */
+    int min_len = WABISABI_VALUE_SIZE + WABISABI_CREDENTIAL_COUNT * WABISABI_PRESENTATION_SIZE + 1 + 1;
     if (req_len < min_len) {
         return WABISABI_ERR_INVALID_LENGTH;
     }
@@ -559,7 +562,15 @@ wabisabi_issuer_handle_real(const uint8_t* sk_bytes, int64_t max_amount,
         off += n;
     }
 
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    if (off >= req_len) {
+        return WABISABI_ERR_INVALID_LENGTH;
+    }
+    req.n_requested = req_bytes[off++];
+    if (req.n_requested != 0 && req.n_requested != WABISABI_CREDENTIAL_COUNT) {
+        return WABISABI_ERR_INVALID_CRED_COUNT;
+    }
+
+    for (int i = 0; i < req.n_requested; i++) {
         int n = read_issuance_request(req_bytes + off, req_len - off, &req.requested[i], w);
         if (n < 0) return WABISABI_ERR_PARSE;
         off += n;
@@ -586,8 +597,8 @@ wabisabi_issuer_handle_real(const uint8_t* sk_bytes, int64_t max_amount,
         return err;
     }
 
-    int resp_needed = WABISABI_CREDENTIAL_COUNT * WABISABI_MAC_SIZE;
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    int resp_needed = 1 + resp.n_issued * WABISABI_MAC_SIZE;
+    for (int i = 0; i < resp.n_issued; i++) {
         resp_needed += proof_serialized_size(&resp.proofs[i]);
     }
     if (resp_out_cap < resp_needed
@@ -596,10 +607,11 @@ wabisabi_issuer_handle_real(const uint8_t* sk_bytes, int64_t max_amount,
     }
 
     off = 0;
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    resp_out[off++] = (uint8_t)resp.n_issued;
+    for (int i = 0; i < resp.n_issued; i++) {
         off += write_mac(resp_out + off, &resp.issued[i]);
     }
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    for (int i = 0; i < resp.n_issued; i++) {
         int n = write_proof(resp_out + off, &resp.proofs[i]);
         if (n < 0) return WABISABI_ERR_PARSE;
         off += n;
@@ -704,8 +716,9 @@ wabisabi_client_create_real_request(const uint8_t* iparams_bytes, int64_t max_am
 
     int req_needed = WABISABI_VALUE_SIZE
                    + WABISABI_CREDENTIAL_COUNT * WABISABI_PRESENTATION_SIZE
+                   + 1  /* n_requested byte */
                    + 1; /* n_proofs byte */
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    for (int i = 0; i < req.n_requested; i++) {
         req_needed += issuance_request_serialized_size(&req.requested[i]);
     }
     for (int i = 0; i < req.n_proofs; i++) {
@@ -726,7 +739,8 @@ wabisabi_client_create_real_request(const uint8_t* iparams_bytes, int64_t max_am
         off += write_presentation(req_out + off, &req.presented[i]);
     }
 
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    req_out[off++] = (uint8_t)req.n_requested;
+    for (int i = 0; i < req.n_requested; i++) {
         off += write_issuance_request(req_out + off, &req.requested[i]);
     }
 
@@ -756,12 +770,9 @@ wabisabi_client_handle_response(const uint8_t* iparams_bytes,
         return WABISABI_ERR_NULL_PTR;
     }
 
-    int min_len = WABISABI_CREDENTIAL_COUNT * WABISABI_MAC_SIZE;
-    if (resp_len < min_len) {
+    /* n_issued byte + at least that many MACs (validated after reading count) */
+    if (resp_len < 1) {
         return WABISABI_ERR_INVALID_LENGTH;
-    }
-    if (creds_out_cap < WABISABI_CREDENTIAL_COUNT * WABISABI_CREDENTIAL_SIZE) {
-        return WABISABI_ERR_BUFFER_TOO_SMALL;
     }
 
     wabisabi_iparams_t ip;
@@ -782,12 +793,19 @@ wabisabi_client_handle_response(const uint8_t* iparams_bytes,
 
     wabisabi_response_t resp;
     int off = 0;
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    resp.n_issued = resp_bytes[off++];
+    if (resp.n_issued != 0 && resp.n_issued != WABISABI_CREDENTIAL_COUNT) {
+        return WABISABI_ERR_INVALID_CRED_COUNT;
+    }
+    if (creds_out_cap < resp.n_issued * WABISABI_CREDENTIAL_SIZE) {
+        return WABISABI_ERR_BUFFER_TOO_SMALL;
+    }
+    for (int i = 0; i < resp.n_issued; i++) {
         int n = read_mac(resp_bytes + off, resp_len - off, &resp.issued[i]);
         if (n < 0) return WABISABI_ERR_PARSE;
         off += n;
     }
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    for (int i = 0; i < resp.n_issued; i++) {
         int n = read_proof(resp_bytes + off, resp_len - off, &resp.proofs[i]);
         if (n < 0) return WABISABI_ERR_PARSE;
         off += n;
@@ -800,11 +818,11 @@ wabisabi_client_handle_response(const uint8_t* iparams_bytes,
         return err;
     }
 
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    for (int i = 0; i < resp.n_issued; i++) {
         write_credential(creds_out + i * WABISABI_CREDENTIAL_SIZE, &creds[i]);
     }
 
     secure_zero(creds, sizeof(creds));
-    *n_creds_out = WABISABI_CREDENTIAL_COUNT;
+    *n_creds_out = resp.n_issued;
     return WABISABI_OK;
 }

--- a/c/src/issuer.c
+++ b/c/src/issuer.c
@@ -162,14 +162,21 @@ wabisabi_issuer_state_handle_zero(wabisabi_issuer_state_t* issuer, const wabisab
 
     free(issue_knowledge);
 
+    resp->n_issued = WABISABI_CREDENTIAL_COUNT;
     return WABISABI_OK;
 }
 
 wabisabi_error_t
 wabisabi_issuer_state_handle_real(wabisabi_issuer_state_t* issuer, const wabisabi_real_request_t* req,
                                   wabisabi_response_t* resp, const uint8_t* random_bytes) {
+    /* A real request either requests no credentials (presentation-only, e.g.
+     * output registration) or the full WABISABI_CREDENTIAL_COUNT. */
+    if (req->n_requested != 0 && req->n_requested != WABISABI_CREDENTIAL_COUNT) {
+        return WABISABI_ERR_INVALID_CRED_COUNT;
+    }
+
     /* Validate bit commitment count */
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    for (int i = 0; i < req->n_requested; i++) {
         if (req->requested[i].n_bit_commitments != issuer->range_proof_width) {
             return WABISABI_ERR_INVALID_BIT_COMMITMENT;
         }
@@ -220,8 +227,8 @@ wabisabi_issuer_state_handle_real(wabisabi_issuer_state_t* issuer, const wabisab
         statements[n_stmt++] = wabisabi_show_credential_statement(&req->presented[i], &z, &issuer->iparams);
     }
 
-    /* Range proofs */
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    /* Range proofs (none for a presentation-only request) */
+    for (int i = 0; i < req->n_requested; i++) {
         statements[n_stmt++] = wabisabi_range_proof_statement(&req->requested[i].ma, req->requested[i].bit_commitments,
                                                               issuer->range_proof_width);
     }
@@ -232,6 +239,8 @@ wabisabi_issuer_state_handle_real(wabisabi_issuer_state_t* issuer, const wabisab
         wabisabi_ge_t sum_ma = {.is_infinity = 1};
         for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
             wabisabi_ge_add(&sum_ca, &sum_ca, &req->presented[i].ca);
+        }
+        for (int i = 0; i < req->n_requested; i++) {
             wabisabi_ge_add(&sum_ma, &sum_ma, &req->requested[i].ma);
         }
 
@@ -279,9 +288,10 @@ wabisabi_issuer_state_handle_real(wabisabi_issuer_state_t* issuer, const wabisab
 
     issuer->balance += req->delta;
 
-    /* Continue with post-verification transcript (don't rebuild) */
+    /* Continue with post-verification transcript (don't rebuild).
+     * A presentation-only request (n_requested == 0) issues no credentials. */
     wabisabi_knowledge_t* issue_knowledge = malloc(WABISABI_CREDENTIAL_COUNT * sizeof(wabisabi_knowledge_t));
-    for (int i = 0; i < WABISABI_CREDENTIAL_COUNT; i++) {
+    for (int i = 0; i < req->n_requested; i++) {
         uint8_t t_bytes[WABISABI_SCALAR_SIZE];
         uint8_t seed[WABISABI_SCALAR_SIZE + 1];
         memcpy(seed, random_bytes, WABISABI_SCALAR_SIZE);
@@ -293,10 +303,11 @@ wabisabi_issuer_state_handle_real(wabisabi_issuer_state_t* issuer, const wabisab
         issue_credential(&resp->issued[i], &issue_knowledge[i], issuer, &req->requested[i].ma, t_bytes);
     }
 
-    wabisabi_prove(resp->proofs, &transcript, issue_knowledge, WABISABI_CREDENTIAL_COUNT, random_bytes,
+    wabisabi_prove(resp->proofs, &transcript, issue_knowledge, req->n_requested, random_bytes,
                    WABISABI_SCALAR_SIZE);
 
     free(issue_knowledge);
 
+    resp->n_issued = req->n_requested;
     return WABISABI_OK;
 }

--- a/c/src/issuer.h
+++ b/c/src/issuer.h
@@ -23,6 +23,9 @@ typedef struct {
 typedef struct {
     int64_t delta; /* amount delta */
     wabisabi_presentation_t presented[WABISABI_CREDENTIAL_COUNT];
+    /* Number of requested credentials: 0 for a presentation-only request
+     * (output registration) or WABISABI_CREDENTIAL_COUNT for a normal one. */
+    int n_requested;
     wabisabi_issuance_request_t requested[WABISABI_CREDENTIAL_COUNT];
     wabisabi_proof_t proofs[/* presentations + range + balance */
                             WABISABI_CREDENTIAL_COUNT * 2 + 1];
@@ -31,6 +34,8 @@ typedef struct {
 
 /* Coordinator response */
 typedef struct {
+    /* Number of issued credentials; mirrors the request's n_requested. */
+    int n_issued;
     wabisabi_mac_t issued[WABISABI_CREDENTIAL_COUNT];
     wabisabi_proof_t proofs[WABISABI_CREDENTIAL_COUNT]; /* issuer params proofs */
 } wabisabi_response_t;

--- a/csharp/WabiSabi/Native/CredentialIssuer.cs
+++ b/csharp/WabiSabi/Native/CredentialIssuer.cs
@@ -92,9 +92,7 @@ public class CredentialIssuer
                     _mstateOutBuf, _mstateOutBuf.Length, out mstateOutLen);
 
             if (rc != 0)
-                throw new WabiSabiCryptoException(
-                    WabiSabiCryptoErrorCode.CoordinatorReceivedInvalidProofs,
-                    $"C issuer returned error code {rc}.");
+                throw new WabiSabiCryptoException(MapError(rc), $"C issuer returned error code {rc}.");
 
             // Store compact copy of the updated mutable state.
             _currentMstate = _mstateOutBuf[..mstateOutLen];
@@ -102,6 +100,22 @@ public class CredentialIssuer
             return WireFormat.DeserializeResponse(respOut[..respLen]);
         }
     }
+
+    /// <summary>
+    /// Maps a C FFI error code (see WABISABI_ERR_* in wabisabi_ffi.h) to the matching
+    /// <see cref="WabiSabiCryptoErrorCode"/> the managed <see cref="WabiSabi.Crypto.CredentialIssuer"/>
+    /// would have thrown, so callers that branch on the specific error keep working.
+    /// </summary>
+    private static WabiSabiCryptoErrorCode MapError(int rc) => rc switch
+    {
+        4  => WabiSabiCryptoErrorCode.CoordinatorReceivedInvalidProofs, // INVALID_PROOF
+        5  => WabiSabiCryptoErrorCode.InvalidNumberOfRequestedCredentials, // INVALID_CRED_COUNT
+        6  => WabiSabiCryptoErrorCode.InvalidBitCommitment,            // INVALID_BIT_COMMITMENT
+        7  => WabiSabiCryptoErrorCode.SerialNumberDuplicated,          // SERIAL_DUPLICATED
+        8  => WabiSabiCryptoErrorCode.SerialNumberAlreadyUsed,         // SERIAL_REUSED
+        9  => WabiSabiCryptoErrorCode.NegativeBalance,                 // NEGATIVE_BALANCE
+        _  => WabiSabiCryptoErrorCode.CoordinatorReceivedInvalidProofs,
+    };
 
     /// <summary>Reads the balance from the compact serialized mutable state.</summary>
     private static long ReadBalance(byte[] mstate)

--- a/csharp/WabiSabi/Native/WireFormat.cs
+++ b/csharp/WabiSabi/Native/WireFormat.cs
@@ -23,8 +23,9 @@ namespace WabiSabi.Native;
 ///   Presentation : [Ca][Cx0][Cx1][CV][S]          = PRESENTATION_SIZE bytes
 ///   Credential   : [value:VALUE_SIZE LE][randomness:SCALAR_SIZE][mac:MAC_SIZE] = CREDENTIAL_SIZE bytes
 ///   ZeroRequest  : [Ma_0][Ma_1][proof_0][proof_1]
-///   RealRequest  : [delta:VALUE_SIZE LE][pres_0:PRESENTATION_SIZE][pres_1:PRESENTATION_SIZE][req_0][req_1][n_proofs:1][proofs...]
-///   Response     : [mac_0:MAC_SIZE][mac_1:MAC_SIZE][proof_0][proof_1]
+///   RealRequest  : [delta:VALUE_SIZE LE][pres_0:PRESENTATION_SIZE][pres_1:PRESENTATION_SIZE][n_requested:1][req_0]...[n_proofs:1][proofs...]
+///                  (n_requested is 0 for a presentation-only request, e.g. output registration)
+///   Response     : [n_issued:1][mac_0]...[mac_{n-1}][proof_0]...[proof_{n-1}]
 /// </summary>
 internal static class WireFormat
 {
@@ -154,7 +155,11 @@ internal static class WireFormat
             bytes.AddRange(WriteGe(p.S));
         }
 
-        foreach (var r in req.Requested)
+        // A presentation-only request (output registration) has no requested
+        // credentials; the count distinguishes it from a normal request.
+        var requestedList = req.Requested.ToArray();
+        bytes.Add((byte)requestedList.Length);
+        foreach (var r in requestedList)
         {
             bytes.AddRange(WriteGe(r.Ma));
             foreach (var bc in r.BitCommitments)
@@ -188,8 +193,9 @@ internal static class WireFormat
                 ReadGe(bytes, ref off), ReadGe(bytes, ref off),
                 ReadGe(bytes, ref off));
 
-        var requested = new IssuanceRequest[CredentialCount];
-        for (int i = 0; i < CredentialCount; i++)
+        int nRequested = bytes[off++];
+        var requested = new IssuanceRequest[nRequested];
+        for (int i = 0; i < nRequested; i++)
         {
             var ma   = ReadGe(bytes, ref off);
             var bits = new GroupElement[rangeWidth];
@@ -214,7 +220,10 @@ internal static class WireFormat
     public static byte[] SerializeResponse(CredentialsResponse resp)
     {
         var bytes = new List<byte>();
-        foreach (var mac in resp.IssuedCredentials)
+        var macs = resp.IssuedCredentials.ToArray();
+        // n_issued: 0 for a presentation-only request's response.
+        bytes.Add((byte)macs.Length);
+        foreach (var mac in macs)
             bytes.AddRange(WriteMac(mac));
         foreach (var proof in resp.Proofs)
             bytes.AddRange(WriteProof(proof));
@@ -227,12 +236,13 @@ internal static class WireFormat
     public static CredentialsResponse DeserializeResponse(byte[] bytes)
     {
         int off = 0;
-        var macs   = new MAC[CredentialCount];
-        var proofs = new Proof[CredentialCount];
+        int nIssued = bytes[off++];
+        var macs   = new MAC[nIssued];
+        var proofs = new Proof[nIssued];
 
-        for (int i = 0; i < CredentialCount; i++)
+        for (int i = 0; i < nIssued; i++)
             macs[i] = ReadMac(bytes, ref off);
-        for (int i = 0; i < CredentialCount; i++)
+        for (int i = 0; i < nIssued; i++)
             proofs[i] = ReadProof(bytes, ref off);
 
         return new CredentialsResponse(macs, proofs);

--- a/interop/WabiSabiInterop.Tests/LargeRangeWidthTests.cs
+++ b/interop/WabiSabiInterop.Tests/LargeRangeWidthTests.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using WabiSabi.Crypto;
+using WabiSabi.CredentialRequesting;
 using Xunit;
 using NativeClient = WabiSabi.Native.WabiSabiClient;
 using CsClient     = WabiSabi.Crypto.WabiSabiClient;
@@ -94,6 +95,42 @@ public class LargeRangeWidthTests
 
         Assert.Equal(2, creds.Length);
         Assert.Equal(Amounts.Sum(), creds.Sum(c => c.Value));
+    }
+
+    // Reproduces the WalletWasabi output-registration flow: a managed client first
+    // obtains real credentials, then issues a *presentation-only* request (presents the
+    // credentials, requests none) against the native issuer. This shape — Delta < 0 with
+    // zero requested credentials — was unrepresentable in the FFI wire format and made the
+    // native issuer fail with a parse error (WABISABI_ERR_PARSE). The native issuer must
+    // verify it and return an empty (zero-credential) response.
+    [Fact]
+    public void PresentationOnly_CSharpClient_NativeIssuer()
+    {
+        var sk      = new CredentialIssuerSecretKey(ChainRng("pres-cs-sk"));
+        var iparams = sk.ComputeCredentialIssuerParameters();
+
+        var client = new CsClient(iparams, ChainRng("pres-cs-client"), WalletWasabiMaxAmount);
+        var issuer = new NativeIssuer(sk, ChainRng("pres-native-issuer"), WalletWasabiMaxAmount);
+
+        // Bootstrap then obtain real credentials worth Amounts.
+        var zero      = client.CreateRequestForZeroAmount();
+        var zeroResp  = issuer.HandleRequest(zero.CredentialsRequest);
+        var zeroCreds = client.HandleResponse(zeroResp, zero.CredentialsResponseValidation).ToArray();
+
+        var real      = client.CreateRequest(Amounts, zeroCreds, CancellationToken.None);
+        var realResp  = issuer.HandleRequest(real.CredentialsRequest);
+        var creds     = client.HandleResponse(realResp, real.CredentialsResponseValidation).ToArray();
+
+        // Presentation-only request: present the credentials, request nothing.
+        var present     = client.CreateRequest(creds, CancellationToken.None);
+        Assert.True(present.CredentialsRequest.IsPresentationOnlyRequest());
+
+        var presentResp = issuer.HandleRequest(present.CredentialsRequest);
+        Assert.Empty(presentResp.IssuedCredentials);
+        Assert.Empty(presentResp.Proofs);
+
+        // The balance returned to zero after the presented amount was spent.
+        Assert.Equal(0L, issuer.Balance);
     }
 
     // The native client emits a ZeroCredentialsRequest; round-trip it through the wire


### PR DESCRIPTION
Output registration sends a presentation-only credential request (Delta < 0, zero requested credentials). The FFI wire format hardcoded exactly WABISABI_CREDENTIAL_COUNT issuance requests in both the parser and serializer, so the native issuer failed to parse it (error code 3, WABISABI_ERR_PARSE). The native client never emitted this shape, so the interop suite never covered it.

Extend the wire format with explicit counts: the real request carries n_requested (0 or CREDENTIAL_COUNT) before the issuance requests, and the response carries n_issued. Thread these through the C structs, the issuer handler (range proofs / sum_Ma / issuance only over n_requested; balance proof always present), both serializers/parsers, and WireFormat.cs.

Also map C error codes (WABISABI_ERR_*) to the matching WabiSabiCryptoErrorCode in the native CredentialIssuer wrapper, so callers branching on SerialNumberAlreadyUsed etc. keep working instead of always seeing CoordinatorReceivedInvalidProofs.

Adds PresentationOnly_CSharpClient_NativeIssuer reproducing the WalletWasabi output-registration path.

Verified: C 127/127, managed 125/125, interop 18/18, and WalletWasabi UnitTests.WabiSabi 285/285 with the native coordinator.